### PR TITLE
BUG: Fix failing example test

### DIFF
--- a/RawImageGuess/RawImageGuess.py
+++ b/RawImageGuess/RawImageGuess.py
@@ -377,6 +377,20 @@ class RawImageGuessLogic(ScriptedLoadableModuleLogic):
     elif scalarTypeStr == "24 bit RGB":
       return (vtk.VTK_UNSIGNED_CHAR, 3)
 
+  def hasImageData(self, volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
+
 class RawImageGuessTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.


### PR DESCRIPTION
This fixes a [failing test](http://slicer.cdash.org/testDetails.php?test=9860399&build=1784809) due to the example test from the [template](https://github.com/Slicer/Slicer/blob/aedb7d6702a30b485be952f2c933dfd96f072f02/Utilities/Templates/Modules/ScriptedDesigner/TemplateKey.py) not having the corresponding example logic function.

Ideally a real test would be added by the maintainers as there already appears to be a "testdata" directory in the repo, but this at least makes sure the example test will succeed.